### PR TITLE
Add SHA256 checksums to release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,18 +79,18 @@ jobs:
       - uses: actions/download-artifact@v4
 
       - name: Generate sha256 checksums
+        shell: bash
         run: |
           shopt -s globstar nullglob
-          : > SHA256SUMS.txt
-          for file in **/ftdc-importer-*; do
-            if [[ -f "$file" ]]; then
-              sha256sum "$file" >> SHA256SUMS.txt
-            fi
+          for file in **/ftdc-importer-*.tar.gz **/ftdc-importer-*.zip; do
+            sha256sum "$file" > "$file.sha256"
           done
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            **/ftdc-importer-*
-            SHA256SUMS.txt
+            **/ftdc-importer-*.tar.gz
+            **/ftdc-importer-*.zip
+            **/ftdc-importer-*.tar.gz.sha256
+            **/ftdc-importer-*.zip.sha256

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,20 @@ jobs:
       contents: write
     steps:
       - uses: actions/download-artifact@v4
+
+      - name: Generate sha256 checksums
+        run: |
+          shopt -s globstar nullglob
+          : > SHA256SUMS.txt
+          for file in **/ftdc-importer-*; do
+            if [[ -f "$file" ]]; then
+              sha256sum "$file" >> SHA256SUMS.txt
+            fi
+          done
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
-          files: "**/ftdc-importer-*"
+          files: |
+            **/ftdc-importer-*
+            SHA256SUMS.txt


### PR DESCRIPTION
### Motivation
- Ensure reproducibility and integrity of published release archives by generating and attaching SHA256 checksums to the GitHub Release.

### Description
- Add a `publish`-job step in `.github/workflows/release.yml` that generates `SHA256SUMS.txt` by running `sha256sum` over all `**/ftdc-importer-*` artifacts (with `shopt -s globstar nullglob` to locate them).
- Update the `softprops/action-gh-release` `files` list to include both `**/ftdc-importer-*` and the generated `SHA256SUMS.txt` so checksums are uploaded alongside the archives.

### Testing
- No automated tests were executed locally because this change only modifies the CI release workflow; the new step will be exercised by the CI `publish` job on the next tagged release run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a682dc0f888327b7a58e8a95783a13)